### PR TITLE
fix: insert a whitespace ' ' after colon

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 	//组合信息 Portfolio information
 	function messageCombine(config: GitMessage) {
-		return `${config.type}(${config.scope}):${config.subject}\n${config.body}\n${config.footer}`;
+		return `${config.type}(${config.scope}): ${config.subject}\n${config.body}\n${config.footer}`;
 	}
 	const gitExtension = getGitExtension();
 	if (!gitExtension?.enabled) {


### PR DESCRIPTION
According to Angular Team's spec, there should be a ' ' after colon before subject.
This PR fixes that problem (addressed in #3).

![image](https://user-images.githubusercontent.com/8528761/77090382-073c4e80-6a42-11ea-8c2b-9d025e194f72.png)
